### PR TITLE
pause/resume should not be called if not a function

### DIFF
--- a/lib/adapters/node-serialport.js
+++ b/lib/adapters/node-serialport.js
@@ -55,13 +55,13 @@ function write (data, callback) {
 }
 
 function pause () {
-    if (process.platform !== 'win32') {
+    if (this._sp.pause instanceof Function) {
         this._sp.pause();
     }
 }
 
 function resume () {
-    if (process.platform !== 'win32') {
+    if (this._sp.resume instanceof Function) {
         this._sp.resume();
     }
 }

--- a/lib/adapters/node-serialport.js
+++ b/lib/adapters/node-serialport.js
@@ -55,11 +55,15 @@ function write (data, callback) {
 }
 
 function pause () {
-  this._sp.pause();
+    if (process.platform !== 'win32') {
+        this._sp.pause();
+    }
 }
 
 function resume () {
-  this._sp.resume();
+    if (process.platform !== 'win32') {
+        this._sp.resume();
+    }
 }
 
 /**


### PR DESCRIPTION
Verify that pause/resume variables are instanceof Function before calling them to avoid crashing on systems like Win32 where they do not exist.
